### PR TITLE
Sb 14996 - New API endpoint: Log

### DIFF
--- a/Api/LogInterface.php
+++ b/Api/LogInterface.php
@@ -11,17 +11,19 @@ interface LogInterface
 
     /**
      * @param string $filename
-     * @return string|null
+     * @param int $lineCount
+     * @return array|string
      */
-    public function retrieve($filename = "system.log");
+    public function retrieve($filename = "system", $lineCount = 100);
     /**
      * @param string $filename
-     * @return string|null
+     * @return int|string
      */
-    public function lineCount($filename = "system.log");
+    public function lineCount($filename = "system");
     /**
      * @param string $filename
-     * @return string|null
+     * @param string $precision
+     * @return string
      */
-    public function fileSize($filename = "system.log");
+    public function fileSize($filename = "system", $precision = 2);
 }

--- a/Api/LogInterface.php
+++ b/Api/LogInterface.php
@@ -13,5 +13,15 @@ interface LogInterface
      * @param string $filename
      * @return string|null
      */
-    public function retrieve($filename="system.log");
+    public function retrieve($filename = "system.log");
+    /**
+     * @param string $filename
+     * @return string|null
+     */
+    public function lineCount($filename = "system.log");
+    /**
+     * @param string $filename
+     * @return string|null
+     */
+    public function fileSize($filename = "system.log");
 }

--- a/Api/LogInterface.php
+++ b/Api/LogInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Springbot\Main\Api;
+
+/**
+ * Interface LogInterface
+ * @package Springbot\Main\Api
+ */
+interface LogInterface
+{
+
+    /**
+     * @param string $filename
+     * @return string|null
+     */
+    public function retrieve($filename="system.log");
+}

--- a/Model/Api/Log.php
+++ b/Model/Api/Log.php
@@ -11,23 +11,13 @@ use Springbot\Main\Api\LogInterface;
  */
 class Log extends AbstractModel implements LogInterface
 {
+    private static $docroot = null;
     /**
      * @param TypeListInterface $logTypeList
      * @param StateInterface $logState
      * @param Pool $pool
      */
     public function __construct()
-    {
-        #
-    }
-
-    /**
-     * Retrieve logs
-     *
-     * @param string $filename
-     * @return string|null
-     */
-    public function retrieve($filename = "system.log")
     {
         $unixFriendly = str_replace('\\', '/', __DIR__);
         $fullArray = explode('/', $unixFriendly);
@@ -36,7 +26,59 @@ class Log extends AbstractModel implements LogInterface
         array_pop($fullArray);
         array_pop($fullArray);
         array_pop($fullArray);
-        $docroot = implode('/', $fullArray) . '/';
-        return file_get_contents($docroot . 'var/log/' . $filename);
+        self::$docroot = implode('/', $fullArray)  . '/var/log/';
+    }
+    /**
+     * @param  string
+     * @return [type]
+     */
+    public function lineCount($filename = "system.log")
+    {
+        $filename = self::$docroot + $filename;
+        $linecount = 0;
+        $file = fopen($filename, "r");
+        while (!feof($file)) {
+            $line = fgets($file);
+            $linecount++;
+        }
+        fclose($file);
+
+        return $linecount;
+    }
+    /**
+     * @param  string
+     * @param  integer
+     * @return [type]
+     */
+    public function fileSize($filename = "system.log", $precision = 2)
+    {
+        $bytes = fileSize(self::$docroot . $filename);
+        $units = array("b", "kb", "mb", "gb", "tb");
+
+        $bytes = max($bytes, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, count($units) - 1);
+
+        $bytes /= (1 << (10 * $pow));
+
+        return round($bytes, $precision) . " " . $units[$pow];
+    }
+    /**
+     * Retrieve logs
+     *
+     * @param string $filename
+     * @return string|null
+     */
+    public function retrieve($filename = "system.log", $lineCount = 100)
+    {
+        $path = self::$docroot . $filename;
+        $handle = fopen($path, "r");
+
+        while (!feof($handle)) {
+            $out[] = trim(fgets($handle));
+        }
+
+        fclose($handle);
+        return $out;
     }
 }

--- a/Model/Api/Log.php
+++ b/Model/Api/Log.php
@@ -16,7 +16,8 @@ class Log extends AbstractModel implements LogInterface
      * @param StateInterface $logState
      * @param Pool $pool
      */
-    public function __construct() {
+    public function __construct()
+    {
         #
     }
 
@@ -26,8 +27,16 @@ class Log extends AbstractModel implements LogInterface
      * @param string $filename
      * @return string|null
      */
-    public function retrieve($filename="system.log")
+    public function retrieve($filename = "system.log")
     {
-        return array('success');
+        $unixFriendly = str_replace('\\', '/', __DIR__);
+        $fullArray = explode('/', $unixFriendly);
+        array_pop($fullArray);
+        array_pop($fullArray);
+        array_pop($fullArray);
+        array_pop($fullArray);
+        array_pop($fullArray);
+        $docroot = implode('/', $fullArray) . '/';
+        return file_get_contents($docroot . 'var/log/' . $filename);
     }
 }

--- a/Model/Api/Log.php
+++ b/Model/Api/Log.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Springbot\Main\Model\Api;
+
+use Magento\Framework\Model\AbstractModel;
+use Springbot\Main\Api\LogInterface;
+
+/**
+ * Class Log
+ * @package Springbot\Main\Api
+ */
+class Log extends AbstractModel implements LogInterface
+{
+    /**
+     * @param TypeListInterface $logTypeList
+     * @param StateInterface $logState
+     * @param Pool $pool
+     */
+    public function __construct() {
+        #
+    }
+
+    /**
+     * Retrieve logs
+     *
+     * @param string $filename
+     * @return string|null
+     */
+    public function retrieve($filename="system.log")
+    {
+        return array('success');
+    }
+}

--- a/Test/Unit/Controller/Index/IndexTest.php
+++ b/Test/Unit/Controller/Index/IndexTest.php
@@ -2,7 +2,7 @@
 
 namespace Springbot\Main\Test\Unit\Controller\Index;
 
-class IndexTest extends \PHPUnit_Framework_TestCase
+class IndexTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject| \Springbot\Main\Controller\Adminhtml\Index\Index

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   php:
-    version: 7.0.4
+    version: 7.0.7
 
 dependencies:
   pre:

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -17,6 +17,7 @@
     <preference for="Springbot\Main\Api\Amazon\Order\AddressInterface" type="Springbot\Main\Model\Api\Amazon\Order\Address"/>
     <preference for="Springbot\Main\Api\Amazon\Order\ItemInterface" type="Springbot\Main\Model\Api\Amazon\Order\Item"/>
     <preference for="Springbot\Main\Api\Amazon\Order\Item\PriceInterface" type="Springbot\Main\Model\Api\Amazon\Order\Item\Price"/>
+    <preference for="Springbot\Main\Api\LogInterface" type="Springbot\Main\Model\Api\Log"/>
     <preference for="Springbot\Main\Api\CacheInterface" type="Springbot\Main\Model\Api\Cache"/>
     <preference for="Springbot\Main\Api\ConfigInterface" type="Springbot\Main\Model\Api\Config"/>
     <preference for="Springbot\Main\Api\ConfigItemInterface" type="Springbot\Main\Model\Api\ConfigItem"/>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -10,6 +10,18 @@
             <resource ref="Springbot_Main::api"/>
         </resources>
     </route>
+    <route url="/V1/springbot/main/log/lineCount" method="POST">
+        <service class="Springbot\Main\Api\LogInterface" method="lineCount"/>
+        <resources>
+            <resource ref="Springbot_Main::api"/>
+        </resources>
+    </route>
+    <route url="/V1/springbot/main/log/fileSize" method="POST">
+        <service class="Springbot\Main\Api\LogInterface" method="fileSize"/>
+        <resources>
+            <resource ref="Springbot_Main::api"/>
+        </resources>
+    </route>
     <route url="/V1/springbot/main/cache/clean" method="POST">
         <service class="Springbot\Main\Api\CacheInterface" method="clean"/>
         <resources>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -4,6 +4,12 @@
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
 
     <!-- Begin instance endpoints -->
+    <route url="/V1/springbot/main/log/retrieve" method="POST">
+        <service class="Springbot\Main\Api\LogInterface" method="retrieve"/>
+        <resources>
+            <resource ref="Springbot_Main::api"/>
+        </resources>
+    </route>
     <route url="/V1/springbot/main/cache/clean" method="POST">
         <service class="Springbot\Main\Api\CacheInterface" method="clean"/>
         <resources>


### PR DESCRIPTION
This updates introduces a Log endpoint to the magento2 plugin API. This is intended to make log retrievals and debugging easier for the dev/ops teams.

### Features:
main/log/retrieve?filename=system&lineCount=50
This will retrieve the last 50 lines of the system.log file located under the `~root/var/log/` folder
**NOTE: linecounts are the last x lines of a file, this function will retrieve 100 lines by default.**

main/log/fileSize?filename=system&precision=2
This will retrieve the current size of the system.log file to 2 decimal places and formatted. **NOTE: 2 decimal places is the default value when none is provided.**

main/log/lineCount?filename=system
This will retrieve the total number of lines from the system.log file and return it as an integer. 

### Additional information:
It may be worth adding features in the future to allow log retrieval by date ranges. I did not add this with this revision in order to allow this to be tested and proven before adding additional complications.

  