### PR TITLE
Bundled products

### DIFF
--- a/Model/Api/Entity/Data/Product.php
+++ b/Model/Api/Entity/Data/Product.php
@@ -321,14 +321,17 @@ class Product implements ProductInterface
         $idColumnName = $this->getIdColumnName();
         $resource =  $this->connectionResource;
         $conn = $resource->getConnection();
-        $query = $conn->query("SELECT cpe.sku FROM {$resource->getTableName('catalog_product_relation')} cper
+
+        $query = $conn->query("SELECT cpe.sku,cpe.type_id FROM {$resource->getTableName('catalog_product_relation')} cper
             LEFT JOIN {$resource->getTableName('catalog_product_entity')} cpe
               ON (cper.parent_id = cpe.{$idColumnName})
                 WHERE cper.child_id = :{$idColumnName}
         ", [$idColumnName => $this->productId]);
         $skus = [];
         foreach ($query->fetchAll() as $parentRow) {
+          if ($parentRow['type_id'] != 'bundle') {
             $skus[] = $parentRow['sku'];
+          }
         }
         return $skus;
     }

--- a/Model/Api/Entity/Data/Product.php
+++ b/Model/Api/Entity/Data/Product.php
@@ -321,7 +321,6 @@ class Product implements ProductInterface
         $idColumnName = $this->getIdColumnName();
         $resource =  $this->connectionResource;
         $conn = $resource->getConnection();
-
         $query = $conn->query("SELECT cpe.sku,cpe.type_id FROM {$resource->getTableName('catalog_product_relation')} cper
             LEFT JOIN {$resource->getTableName('catalog_product_entity')} cpe
               ON (cper.parent_id = cpe.{$idColumnName})


### PR DESCRIPTION
Added a conditional to prevent adding bundled products to the parent skus, this should prevent the ETL from improperly harvesting products in bundles and treating them as children.