### PR TITLE
1.8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "springbot/magento2-plugin",
   "description": "Springbot integration for Magento 2",
   "type": "magento2-module",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "license": [
     "OSL-3.0"
   ],

--- a/etc/frontend/routes.xml
+++ b/etc/frontend/routes.xml
@@ -8,8 +8,5 @@
     <route id="springbot_createcart" frontName="springbot">
       <module name="Springbot_Main"/>
     </route>
-    <route id="springbot_product" frontName="springbot">
-      <module name="Springbot_Main"/>
-    </route>
   </router>
 </config>


### PR DESCRIPTION
This is to revert the bad route which is causing installation issues. We can re-release a new version once we complete the changes to resolve the route conflict but we have other updates that customers will need for new features so we can't hold up master any more.