### PR TITLE
V2 Product Attribute Values Fix

### DIFF
--- a/Model/Api/Entity/Data/V2Product.php
+++ b/Model/Api/Entity/Data/V2Product.php
@@ -229,7 +229,7 @@ class V2Product extends MagentoProduct implements V2ProductInterface
     {
         $attributes = [];
         foreach (parent::getCustomAttributes() as $customAttribute) {
-            $attributes[] = new ProductAttribute($customAttribute->getAttributeCode(), $customAttribute->getValue());
+            $attributes[] = new ProductAttribute($customAttribute->getAttributeCode(), $this->getResource()->getAttribute($customAttribute->getAttributeCode())->getFrontend()->getValue($this));
         }
         return $attributes;
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "springbot/magento2-plugin",
   "description": "Springbot integration for Magento 2",
   "type": "magento2-module",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "license": [
     "OSL-3.0"
   ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -2,5 +2,5 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Springbot_Main" setup_version="1.9.5"/>
+    <module name="Springbot_Main" setup_version="1.9.6"/>
 </config>


### PR DESCRIPTION
This changes they way we get the attribute values and fixes the issue where we get the ID rather than the name.

I have tested it on my qa store m2.saleturf.com 11701
![image](https://user-images.githubusercontent.com/41336205/72289428-1b666880-3619-11ea-8099-e68be2ed9a0f.png)
