### PR TITLE
SB3-1123 add AdRoll currency value to success page 

### DIFF
--- a/Block/EnhancedPixel.php
+++ b/Block/EnhancedPixel.php
@@ -74,7 +74,6 @@ class EnhancedPixel extends Template
         return $this->getLastOrder()->getIncrementId();
     }
 
-
     /**
      * @return string
      */

--- a/Block/EnhancedPixel.php
+++ b/Block/EnhancedPixel.php
@@ -74,6 +74,15 @@ class EnhancedPixel extends Template
         return $this->getLastOrder()->getIncrementId();
     }
 
+
+    /**
+     * @return string
+     */
+    public function getOrderCurrencyCode()
+    {
+        return $this->getLastOrder()->getOrderCurrencyCode();
+    }
+
     /**
      * @return string
      */

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "springbot/magento2-plugin",
   "description": "Springbot integration for Magento 2",
   "type": "magento2-module",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "license": [
     "OSL-3.0"
   ],

--- a/view/frontend/templates/main/enhanced_pixel.phtml
+++ b/view/frontend/templates/main/enhanced_pixel.phtml
@@ -1,5 +1,6 @@
 <script type="text/javascript">
-    adroll_conversion_value_in_dollars = <?php echo $block->getConversionValueInDollars() ?>;
+    adroll_conversion_value = <?php echo $block->getConversionValueInDollars() ?>;
+    adroll_currency = <?php echo $block->getOrderCurrencyCode() ?>;
     adroll_custom_data = {"ORDER_ID": "<?php echo $block->getIncrementId() ?>"};
 
     function getTransCookie() {
@@ -10,7 +11,7 @@
       }
       return transitivCookie;
     }
-    
+
     window._sb_conversion = {
         id: <?php echo $block->getIncrementId() ?>,
         total: <?php echo $block->getConversionValueInDollars() ?>,

--- a/view/frontend/templates/main/enhanced_pixel.phtml
+++ b/view/frontend/templates/main/enhanced_pixel.phtml
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     adroll_conversion_value = <?php echo $block->getConversionValueInDollars() ?>;
-    adroll_currency = <?php echo $block->getOrderCurrencyCode() ?>;
+    adroll_currency = "<?php echo $block->getOrderCurrencyCode() ?>";
     adroll_custom_data = {"ORDER_ID": "<?php echo $block->getIncrementId() ?>"};
 
     function getTransCookie() {


### PR DESCRIPTION
This adds the currency to the adroll script so that adroll can track based on currency.
Deployed and tested on https://m2.saleturf.com/